### PR TITLE
Make MHD restarts bitwise identical

### DIFF
--- a/src/mesh/meshblock.cpp
+++ b/src/mesh/meshblock.cpp
@@ -315,14 +315,17 @@ MeshBlock::MeshBlock(int igid, int ilid, Mesh *pm, ParameterInput *pin,
   }
   if (MAGNETIC_FIELDS_ENABLED) {
     std::memcpy(pfield->b.x1f.data(), &(mbdata[os]), pfield->b.x1f.GetSizeInBytes());
-    std::memcpy(pfield->b1.x1f.data(), &(mbdata[os]), pfield->b1.x1f.GetSizeInBytes());
     os += pfield->b.x1f.GetSizeInBytes();
+    std::memcpy(pfield->b1.x1f.data(), &(mbdata[os]), pfield->b1.x1f.GetSizeInBytes());
+    os += pfield->b1.x1f.GetSizeInBytes();
     std::memcpy(pfield->b.x2f.data(), &(mbdata[os]), pfield->b.x2f.GetSizeInBytes());
-    std::memcpy(pfield->b1.x2f.data(), &(mbdata[os]), pfield->b1.x2f.GetSizeInBytes());
     os += pfield->b.x2f.GetSizeInBytes();
+    std::memcpy(pfield->b1.x2f.data(), &(mbdata[os]), pfield->b1.x2f.GetSizeInBytes());
+    os += pfield->b1.x2f.GetSizeInBytes();
     std::memcpy(pfield->b.x3f.data(), &(mbdata[os]), pfield->b.x3f.GetSizeInBytes());
-    std::memcpy(pfield->b1.x3f.data(), &(mbdata[os]), pfield->b1.x3f.GetSizeInBytes());
     os += pfield->b.x3f.GetSizeInBytes();
+    std::memcpy(pfield->b1.x3f.data(), &(mbdata[os]), pfield->b1.x3f.GetSizeInBytes());
+    os += pfield->b1.x3f.GetSizeInBytes();
   }
 
   // (conserved variable) Passive scalars:
@@ -456,8 +459,10 @@ std::size_t MeshBlock::GetBlockSizeInBytes() {
     size += phydro->w1.GetSizeInBytes();
   }
   if (MAGNETIC_FIELDS_ENABLED)
-    size += (pfield->b.x1f.GetSizeInBytes() + pfield->b.x2f.GetSizeInBytes()
-             + pfield->b.x3f.GetSizeInBytes());
+    size +=
+      pfield->b.x1f.GetSizeInBytes() + pfield->b1.x1f.GetSizeInBytes() +
+      pfield->b.x2f.GetSizeInBytes() + pfield->b1.x2f.GetSizeInBytes() +
+      pfield->b.x3f.GetSizeInBytes() + pfield->b1.x3f.GetSizeInBytes();
   if (SELF_GRAVITY_ENABLED)
     size += pgrav->phi.GetSizeInBytes();
   if (NSCALARS > 0)

--- a/src/outputs/restart.cpp
+++ b/src/outputs/restart.cpp
@@ -164,10 +164,16 @@ void RestartOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool force_wr
     if (MAGNETIC_FIELDS_ENABLED) {
       std::memcpy(pdata, pmb->pfield->b.x1f.data(), pmb->pfield->b.x1f.GetSizeInBytes());
       pdata += pmb->pfield->b.x1f.GetSizeInBytes();
+      std::memcpy(pdata, pmb->pfield->b1.x1f.data(), pmb->pfield->b1.x1f.GetSizeInBytes());
+      pdata += pmb->pfield->b1.x1f.GetSizeInBytes();
       std::memcpy(pdata, pmb->pfield->b.x2f.data(), pmb->pfield->b.x2f.GetSizeInBytes());
       pdata += pmb->pfield->b.x2f.GetSizeInBytes();
+      std::memcpy(pdata, pmb->pfield->b1.x2f.data(), pmb->pfield->b1.x2f.GetSizeInBytes());
+      pdata += pmb->pfield->b1.x2f.GetSizeInBytes();
       std::memcpy(pdata, pmb->pfield->b.x3f.data(), pmb->pfield->b.x3f.GetSizeInBytes());
       pdata += pmb->pfield->b.x3f.GetSizeInBytes();
+      std::memcpy(pdata, pmb->pfield->b1.x3f.data(), pmb->pfield->b1.x3f.GetSizeInBytes());
+      pdata += pmb->pfield->b1.x3f.GetSizeInBytes();
     }
 
     // (conserved variable) Passive scalars:


### PR DESCRIPTION
Currently it seems only HD restarts are bitwise identical. This PR attempts to address the MHD situation.